### PR TITLE
Bugfix in beam rule engine:

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,175 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2.1
+executors:
+  vm-executor:
+    machine:
+      enabled: true
+      image: ubuntu-1604:201903-01
+    working_directory: ~/repo
+    environment:
+      shell: /bin/bash
+      TERM: xterm
+      TZ: "Europe/Berlin"
+  docker-executor:
+    docker:
+      - image: circleci/openjdk:8-jdk-stretch
+    working_directory: ~/repo
+    environment:
+      shell: /bin/bash
+      TERM: xterm
+commands:
+  setup-build-environment:
+    description: "Setup build Environment"
+    steps:
+      - run:
+          shell: /bin/bash
+          name: Setup build environment
+          command: |
+            cd platform-launcher/util && \
+            bash setup-ubuntu18.04.sh
+  checkout-e2e:
+    description: "Checkout E2E test"
+    parameters:
+      repo:
+        type: string
+    steps:
+      - run:
+          name: Checkout E2E test and adjust << parameters.repo >> repo
+          shell: /bin/bash
+          command: |
+            git clone https://github.com/${CIRCLE_PROJECT_USERNAME}/platform-launcher.git
+            cd platform-launcher
+            git checkout develop
+            git submodule init
+            git submodule update
+            yes | make update
+  check-signed:
+    description: "Check whether latest commit is signed"
+    steps:
+      - run:
+          name: Check whether most recent commit is signed
+          command: |
+            MESSAGE=`git log -1 --pretty=%B`
+            echo "Checking whether signed"
+            if [[ "${MESSAGE}" == *Signed-off-by:*@* ]]; then
+              echo "Commit is signedoff"
+            else
+              echo "Commit is not signedoff"
+              exit 1
+            fi
+  checkout-testbranch:
+    description: "Checks out branch of repository which is to be tested"
+    parameters:
+      repo:
+        type: string
+    steps:
+      - run:
+          name: Checks out branch of to be tested repository
+          command: |
+            CLONE_REPO=https://github.com/${CIRCLE_PROJECT_USERNAME}/<< parameters.repo >>.git
+            CLONE_BRANCH=${CIRCLE_BRANCH}
+            if [ ! -z "${CIRCLE_PULL_REQUEST}" ]; then
+              PR=${CIRCLE_PR_NUMBER}
+              PR_REPO=${CIRCLE_PR_REPONAME}
+              PROJECT_USERNAME=${CIRCLE_PROJECT_USERNAME}
+              URL="https://api.github.com/repos/${PROJECT_USERNAME}/${PR_REPO}/pulls/${PR}"
+              GITHUBDATA=$(curl "$URL")
+              CLONE_REPO=$(echo $GITHUBDATA | jq '.head.repo.clone_url' | tr -d '"')
+              CLONE_BRANCH=$(echo $GITHUBDATA | jq '.head.ref' | tr -d '"')
+              echo Detected Pull Request with clone REPO ${CLONE_REPO} and branch ${CLONE_BRANCH}
+            fi
+            cd platform-launcher
+            rm -rf ${CIRCLE_PROJECT_REPONAME}
+            git clone ${CLONE_REPO}
+            cd ${CIRCLE_PROJECT_REPONAME}
+            git checkout origin/${CLONE_BRANCH}
+  pull-images-and-build-only-testbranch:
+    description: "Pull all images and only build the testbranch"
+    parameters:
+      container:
+        type: string
+    steps:
+      - run:
+          name: Pull all images and only build the testbranch
+          shell: /bin/bash
+          # debugger container is also built
+          # because on k8s the tests run inside the debug contianer
+          command: |
+            cd platform-launcher
+            export CONTAINERS="<< parameters.container >> debugger"
+            if docker login  -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD};
+            then
+                DOCKER_TAG="latest" docker-compose pull
+            else
+                unset CONTAINERS
+            fi
+            yes | make build DOCKER_TAG="test" DEBUG=true
+            # Tag pulled "latest" images as "test"
+            images=$(docker images --format "{{.Repository}}:{{.Tag}}"| grep :latest)
+            for image in $images; do
+              newimage=$(echo $image | sed -r "s/:latest/:test/g");
+              docker tag $image $newimage;
+            done
+  e2e-test:
+    description: "Execute E2E test"
+    steps:
+      - run:
+          name: Execute E2E test
+          shell: /bin/bash
+          command: |
+            cd platform-launcher
+            export PATH=$PATH:/snap/bin
+            make import-images DOCKER_TAG=test DEBUG=true
+            npm install nodemailer
+            export NODOCKERLOGIN=true
+            make deploy-oisp-test DOCKER_TAG=test
+            make test
+jobs:
+  e2e-test:
+    executor: vm-executor
+    steps:
+      - checkout-e2e:
+          repo: "oisp-beam-rule-engine"
+      - checkout-testbranch:
+          repo: "oisp-beam-rule-engine"
+      - setup-build-environment
+      - pull-images-and-build-only-testbranch:
+          container: "rule-engine"
+      - e2e-test
+  build-check:
+    executor: docker-executor
+    steps:
+      - checkout
+      - run:
+          name: Check whether most recent commit is signedoff
+          shell: /bin/bash
+          command: |
+            MESSAGE=`git log -1 --pretty=%B`
+            echo "Checking whether signed"
+            if [[ "${MESSAGE}" == *Signed-off-by:*@* ]]; then
+              echo "Commit is signedoff"
+            else
+              echo "Commit is not signedoff"
+              exit 1
+            fi
+      - run:
+          shell: /bin/bash
+          name: Build
+          command: |
+            mvn clean package -Pflink-runner  -DskipTests
+      - run:
+          shell: /bin/bash
+          name: Run linting and tests
+          command: |
+            mvn checkstyle:check pmd:check
+workflows:
+  version: 2.1
+  workflow:
+    jobs:
+      - build-check
+      - e2e-test:
+          requires:
+            - build-check

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <beam.version>2.12.0</beam.version>
+    <beam.version>2.16.0</beam.version>
 
     <bigquery.version>v2-rev374-1.22.0</bigquery.version>
     <google-clients.version>1.22.0</google-clients.version>

--- a/src/main/java/org/oisp/apiclients/rules/DashboardRulesApi.java
+++ b/src/main/java/org/oisp/apiclients/rules/DashboardRulesApi.java
@@ -22,7 +22,6 @@ import org.oisp.apiclients.CustomRestTemplate;
 import org.oisp.apiclients.DashboardConfig;
 import org.oisp.apiclients.InvalidDashboardResponseException;
 import org.oisp.apiclients.rules.model.ComponentRulesResponse;
-import org.oisp.rules.RuleStatus;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -32,6 +31,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.io.Serializable;
@@ -106,7 +106,11 @@ public class DashboardRulesApi implements RulesApi, Serializable {
         if (synced) {
             syncStatus = RULE_STATUS_SYNCHRONIZED;
         }
-        return new RuleRequest(RuleStatus.asList(), syncStatus);
+        List<String> ruleStatus = new ArrayList<String>();
+        ruleStatus.add("Active");
+        // In the current setup we look only for Active rules
+        // This will change once we have Cassandra to manage changes and only handle unsynced rules
+        return new RuleRequest(ruleStatus, syncStatus);
     }
 
     private String getEndpoint(String restMethod) {

--- a/src/main/java/org/oisp/transformation/CheckRuleFulfillment.java
+++ b/src/main/java/org/oisp/transformation/CheckRuleFulfillment.java
@@ -9,7 +9,6 @@ import org.oisp.collection.RuleWithRuleConditions;
 import org.oisp.rules.ConditionOperators;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 
@@ -26,12 +25,13 @@ public class CheckRuleFulfillment extends DoFn<KV<String, RuleWithRuleConditions
         Map<Integer, RuleCondition> ruleConditionMap = rwrc.getRcHash();
         if (mutableRule.getConditionOperator() == ConditionOperators.AND) {
             Boolean result = true;
-            for (int i = 0; i < mutableRule.getConditions().size(); i++) {
-                List<RuleCondition> rcl = mutableRule.getConditions();
-                if (rcl != null && rcl.get(i) != null && rcl.get(i).getFulfilled()) {
-                    mutableRule.getConditions().set(i, rcl.get(i));
+            for (int i = 0; i < rwrc.getRule().getConditions().size(); i++) {
+                RuleCondition currentRc = ruleConditionMap.get(i);
+                if (currentRc != null  && currentRc.getFulfilled()) {
+                    mutableRule.getConditions().add(currentRc);
                 } else {
                     result = false;
+                    break;
                 }
             }
             if (result) {

--- a/src/main/java/org/oisp/transformation/GetComponentRulesTask.java
+++ b/src/main/java/org/oisp/transformation/GetComponentRulesTask.java
@@ -52,10 +52,11 @@ public class GetComponentRulesTask extends DoFn<List<Observation>, List<RulesWit
 
     @Setup
     public void setup() {
+        System.out.println("Setup of Transform.");
         updateComponentRules();
         componentRuleversion = 0L;
-
     }
+
     public GetComponentRulesTask(Config userConfig, PCollectionView<List<Long>> sideInput) {
         //this(new RulesHbaseRepository(userConfig));
         rulesApi = new DashboardRulesApi(new DashboardConfigProvider(userConfig));

--- a/src/main/java/org/oisp/transformation/PersistRulesTask.java
+++ b/src/main/java/org/oisp/transformation/PersistRulesTask.java
@@ -64,10 +64,10 @@ public class PersistRulesTask extends DoFn<KV<String, Map<String, List<Rule>>>, 
             }
             if (!isRulesEmpty(rules)) {
                 rulesApi.markRulesSynchronized(getRulesIds(rules.values()));
-                counter++;
-                state.write(counter);
-                c.output(counter);
             }
+            counter++;
+            state.write(counter);
+            c.output(counter);
         } catch (InvalidDashboardResponseException e) {
             LOG.error("Unable to mark persisted rules as synchronized in Dashboard", e);
         }


### PR DESCRIPTION
* element processing was only triggered by side-input. When RE is started and there is no rule-update trigger from Kafka, it did not get the rule-set and process elements. Fix: When pipeline is started, there is always an initial trigger to start processing
* AND operator was not working properly, evaluated true in cased when one condition was not yet evaluated
* Only active rules are taken for processing. In future, when we have a proper (non-HBASE) DB backend (Cassandra) we can move back to process only changes in Rules and persist in backend.

Signed-off-by: Marcel Wagner <wagmarcel@web.de>