### PR TITLE
Bump jackson.version from 2.8.9 to 2.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <google-clients.version>1.22.0</google-clients.version>
     <guava.version>20.0</guava.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <jackson.version>2.8.9</jackson.version>
+    <jackson.version>2.10.0</jackson.version>
     <joda.version>2.4</joda.version>
     <junit.version>4.12</junit.version>
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>


### PR DESCRIPTION
Bumps `jackson.version` from 2.8.9 to 2.10.0.

Updates `jackson-databind` from 2.8.9 to 2.10.0
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `jackson-module-scala_2.11` from 2.8.9 to 2.10.0
- [Release notes](https://github.com/FasterXML/jackson-module-scala/releases)
- [Changelog](https://github.com/FasterXML/jackson-module-scala/blob/master/release.sbt)
- [Commits](https://github.com/FasterXML/jackson-module-scala/compare/jackson-module-scala-2.8.9...jackson-module-scala-2.10.0)

Signed-off-by: dependabot[bot] <support@github.com>