### PR TITLE
Remove Heartbeat from RE and add Support for Flink 1.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ commands:
               CLONE_BRANCH=$(echo $GITHUBDATA | jq '.head.ref' | tr -d '"')
               echo Detected Pull Request with clone REPO ${CLONE_REPO} and branch ${CLONE_BRANCH}
             fi
-            cd platform-launcher
+            cd platform-launcher/oisp-services
             rm -rf ${CIRCLE_PROJECT_REPONAME}
             git clone ${CLONE_REPO}
             cd ${CIRCLE_PROJECT_REPONAME}
@@ -125,8 +125,12 @@ commands:
             make import-images DOCKER_TAG=test DEBUG=true
             npm install nodemailer
             export NODOCKERLOGIN=true
-            make deploy-oisp-test DOCKER_TAG=test
-            make test
+            retval=2;
+            until [ ${retval} -eq 0 ]; do
+              (for i in {1..20}; do sleep 60; echo .; done&) &&  make deploy-oisp-test DOCKER_TAG=test USE_LOCAL_REGISTRY=true
+              make test
+              retval=$?
+            done
 jobs:
   e2e-test:
     executor: vm-executor

--- a/pom-next.xml
+++ b/pom-next.xml
@@ -22,12 +22,12 @@
 
   <groupId>org.oisp</groupId>
   <artifactId>rule-engine</artifactId>
-  <version>0.1.1</version>
+  <version>0.1.2</version>
 
   <packaging>jar</packaging>
 
   <properties>
-    <beam.version>2.21.0</beam.version>
+    <beam.version>2.28.0</beam.version>
 
     <bigquery.version>v2-rev374-1.22.0</bigquery.version>
     <google-clients.version>1.22.0</google-clients.version>
@@ -66,7 +66,7 @@
     <repository>
       <id>maven1-repo</id>
       <name>maven1-repo</name>
-      <url>http://repo1.maven.org/maven2</url>
+      <url>https://repo1.maven.org/maven2</url>
     </repository>
 
 
@@ -334,7 +334,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.beam</groupId>
-          <artifactId>beam-runners-flink-1.10</artifactId>
+          <artifactId>beam-runners-flink-1.12</artifactId>
           <version>${beam.version}</version>
           <scope>runtime</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,12 @@
 
   <groupId>org.oisp</groupId>
   <artifactId>rule-engine</artifactId>
-  <version>0.1</version>
+  <version>0.1.1</version>
 
   <packaging>jar</packaging>
 
   <properties>
-    <beam.version>2.16.0</beam.version>
+    <beam.version>2.21.0</beam.version>
 
     <bigquery.version>v2-rev374-1.22.0</bigquery.version>
     <google-clients.version>1.22.0</google-clients.version>
@@ -66,7 +66,7 @@
     <repository>
       <id>maven1-repo</id>
       <name>maven1-repo</name>
-      <url>http://repo1.maven.org/maven2</url>
+      <url>https://repo1.maven.org/maven2</url>
     </repository>
 
 
@@ -334,7 +334,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.beam</groupId>
-          <artifactId>beam-runners-flink-1.7</artifactId>
+          <artifactId>beam-runners-flink-1.10</artifactId>
           <version>${beam.version}</version>
           <scope>runtime</scope>
         </dependency>
@@ -570,12 +570,6 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.3.6</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-client</artifactId>
-      <version>1.4.4</version>
     </dependency>
 
   </dependencies>

--- a/src/main/java/org/oisp/pipeline/FullPipelineBuilder.java
+++ b/src/main/java/org/oisp/pipeline/FullPipelineBuilder.java
@@ -7,7 +7,6 @@ import com.google.gson.reflect.TypeToken;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.GenerateSequence;
-import org.apache.beam.sdk.io.kafka.KafkaIO;
 import org.apache.beam.sdk.io.kafka.KafkaRecord;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -23,7 +22,6 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
 import org.apache.beam.sdk.values.PCollectionView;
-import org.apache.kafka.common.serialization.StringSerializer;
 
 import org.joda.time.Duration;
 import org.oisp.apiclients.ApiFatalException;
@@ -136,20 +134,6 @@ public final class FullPipelineBuilder {
                 .apply(ParDo.of(new PersistRuleState()))
                 .apply(ParDo.of(new CheckRuleFulfillment()))
                 .apply(ParDo.of(sendAlertFromRule));
-
-        //Heartbeat Pipeline
-        //Send regular Heartbeat to Kafka topic
-        String serverUri = conf.get(Config.KAFKA_URI_PROPERTY).toString();
-        System.out.println("serverUri:" + serverUri);
-        p.apply(GenerateSequence.from(0).withRate(1, Duration.standardSeconds(1)))
-                .apply(ParDo.of(new StringToKVFn()))
-                .apply(KafkaIO.<String, String>write()
-                        .withBootstrapServers(serverUri)
-                        .withTopic("heartbeat")
-                        .withKeySerializer(StringSerializer.class)
-                        .withValueSerializer(StringSerializer.class));
-
-
 
         return p;
     }


### PR DESCRIPTION
Heartbeat is a legacy mechanism to monitor health of services. This is no longer needed in Kubernetes setup.
Therefore it can be removed from rule-engine. This PR is proving the following changes:
- Flink 1.10 compatible rule-engine (v0.1.1)
- Flink 1.12/1.13 compatible rule-engine (v0.1.2)
- Removal of heartbeat from the Beam pipeline

Resolves: #19

Signed-off-by: Marcel Wagner <wagmarcel@web.de>